### PR TITLE
下载链接有效期延长到四小时

### DIFF
--- a/alidrive/req_bean.go
+++ b/alidrive/req_bean.go
@@ -22,6 +22,13 @@ type GetReq struct {
 	VideoThumbnailProcess string `json:"video_thumbnail_process"`
 }
 
+// download request bean
+type DownloadReq struct {
+	DriveId               string `json:"drive_id"`
+	FileId                string `json:"file_id"`
+	ExpireSec             int    `json:"expire_sec"`
+}
+
 // search request bean
 type SearchReq struct {
 	DriveId               string `json:"drive_id"`

--- a/alidrive/request.go
+++ b/alidrive/request.go
@@ -28,6 +28,21 @@ func GetFile(fileId string) (*File, error) {
 	return &resp,nil
 }
 
+// get download_url
+func GetDownLoadUrl(fileId string) (*File, error) {
+	url:=conf.Conf.AliDrive.ApiUrl+"/file/get_download_url"
+	req:=DownloadReq{
+		DriveId:               User.DefaultDriveId,
+		FileId:                fileId,
+		ExpireSec:             14400,
+	}
+	var resp File
+	if err := BodyToJson(url, req, &resp, true); err!=nil {
+		return nil,err
+	}
+	return &resp,nil
+}
+
 // search by keyword
 func Search(key string,limit int, marker string) (*Files, error) {
 	url:=conf.Conf.AliDrive.ApiUrl+"/file/search"

--- a/server/controllers/get.go
+++ b/server/controllers/get.go
@@ -37,6 +37,12 @@ func Get(c *gin.Context) {
 		return
 	}
 	file.Paths=*paths
+	download,err:=alidrive.GetDownLoadUrl(get.FileId)
+	if err!=nil {
+		c.JSON(200, MetaResponse(500,err.Error()))
+		return
+	}
+	file.DownloadUrl=download.Url
 	//if conf.Conf.Cache.Enable {
 	//	conf.Cache.Set(cacheKey,file,cache.DefaultExpiration)
 	//}
@@ -56,7 +62,7 @@ func Down(c *gin.Context) {
 	//		return
 	//	}
 	//}
-	file,err:=alidrive.GetFile(fileId)
+	file,err:=alidrive.GetDownLoadUrl(fileId)
 	if err != nil {
 		c.JSON(200, MetaResponse(500,err.Error()))
 		return
@@ -64,6 +70,6 @@ func Down(c *gin.Context) {
 	//if conf.Conf.Cache.Enable {
 	//	conf.Cache.Set(cacheKey,file.DownloadUrl,cache.DefaultExpiration)
 	//}
-	c.Redirect(301,file.DownloadUrl)
+	c.Redirect(301,file.Url)
 	return
 }


### PR DESCRIPTION
#25 昨天提了个issue，今天想想我还是自己写一个吧。
我不会go语言，所以自己照葫芦画瓢写了一个。
利用 /file/get_download_url 设置过期时间，现在直接下载、预览、复制直链跳转的阿里云盘下载直链有效期都延长到了四个小时，对于大文件下载和电影在线预览都更友好了。