### PR TITLE
自定义监听地址配置

### DIFF
--- a/bootstrap/cmd.go
+++ b/bootstrap/cmd.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"flag"
 	"fmt"
+
 	"github.com/Xhofe/alist/conf"
 	serv "github.com/Xhofe/alist/server"
 	"github.com/gin-gonic/gin"
@@ -71,7 +72,7 @@ func start() {
 
 // start http server
 func server() {
-	baseServer := "0.0.0.0:" + conf.Conf.Server.Port
+	baseServer := conf.Conf.Server.Address + ":" + conf.Conf.Server.Port
 	r := gin.Default()
 	serv.InitRouter(r)
 	log.Infof("Starting server @ %s", baseServer)

--- a/conf.yml.example
+++ b/conf.yml.example
@@ -10,6 +10,7 @@ info:
   preview:
     text: [txt,htm,html,xml,java,properties,sql,js,md,json,conf,ini,vue,php,py,bat,gitignore,yml,go,sh,c,cpp,h,hpp] #要预览的文本文件的后缀，可以自行添加
 server:
+  address: "0.0.0.0"
   port: "5244"
   search: true
   static: dist

--- a/conf/config.go
+++ b/conf/config.go
@@ -31,6 +31,7 @@ type Config struct {
 		} `yaml:"preview" json:"preview"`
 	} `yaml:"info"`
 	Server struct {
+		Address  string `yaml:"address"`
 		Port     string `yaml:"port"`   //端口
 		Search   bool   `yaml:"search"` //允许搜索
 		Static   string `yaml:"static"`


### PR DESCRIPTION
通常我使用`Nginx`来对不同的服务进行反代，不喜欢直接将服务端口暴露给公网。PR中增加了`address`配置，可以自定义服务监听的地址，例如`0.0.0.0`以及`127.0.0.1`