### PR TITLE
修复了因为Referer导致不能下载的问题

### DIFF
--- a/alidrive/auth.go
+++ b/alidrive/auth.go
@@ -10,8 +10,8 @@ import (
 // refresh access_token token by refresh_token
 func RefreshToken(drive *conf.Drive) bool {
 	log.Infof("刷新[%s]token...", drive.Name)
-	url := "https://websv.aliyundrive.com/token/refresh"
-	req := RefreshTokenReq{RefreshToken: drive.RefreshToken}
+	url := "https://auth.aliyundrive.com/v2/account/token"
+	req := RefreshTokenReq{RefreshToken: drive.RefreshToken , GrantType: "refresh_token"}
 	var token TokenResp
 	if body, err := DoPost(url, req, ""); err != nil {
 		log.Errorf("tokenLogin-doPost出错:%s", err.Error())

--- a/alidrive/req_bean.go
+++ b/alidrive/req_bean.go
@@ -57,6 +57,7 @@ type GetTokenReq struct {
 // refresh_token request bean
 type RefreshTokenReq struct {
 	RefreshToken string `json:"refresh_token"`
+	GrantType    string `json:"grant_type"`
 }
 
 // office_preview_url request bean


### PR DESCRIPTION
#67 已解决。阿里云盘的手机版获取到的直链不需要Referer请求头就能下载。与网页版获取直链接口多次对比发现是token不同导致生成的直链不同，不同的位置在token第二段，base64解码之后，网页版后面有{"ref":"https://www.aliyun drive.c om/"}，手机版没有，所以把刷新token改为手机版的接口。不知道能撑多久(