### PR TITLE
视频在线观看链接时常延长到4小时

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2020 微凉
-
+s
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2020 微凉
-s
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/alidrive/req_bean.go
+++ b/alidrive/req_bean.go
@@ -71,4 +71,5 @@ type OfficePreviewUrlReq struct {
 type VideoPreviewUrlReq struct {
 	DriveId     string `json:"drive_id"`
 	FileId      string `json:"file_id"`
+	ExpireSec int    `json:"expire_sec"`
 }

--- a/alidrive/request.go
+++ b/alidrive/request.go
@@ -114,6 +114,7 @@ func GetVideoPreviewUrl(fileId string, drive *conf.Drive) (*VideoPreviewUrlResp,
 	req := VideoPreviewUrlReq{
 		DriveId:     drive.DefaultDriveId,
 		FileId:      fileId,
+		ExpireSec: 14400,
 	}
 	var resp VideoPreviewUrlResp
 	if err := BodyToJson(url, req, &resp, drive); err != nil {


### PR DESCRIPTION
以前提过这个问题，不过大佬可能太忙了没时间改
啥都不懂.....根据以前改下载链接时长照着改了一下，测试没问题，视频预览链接变为4小时