### PR TITLE
支持仅秒传模式

### DIFF
--- a/conf.yml.example
+++ b/conf.yml.example
@@ -13,6 +13,7 @@ server:
   address: "0.0.0.0"
   port: "5244"
   search: true
+  download: true //是否允许获取直链
   static: dist
   site_url: '*'
   password: password #用于重建目录

--- a/conf/config.go
+++ b/conf/config.go
@@ -32,8 +32,9 @@ type Config struct {
 	} `yaml:"info"`
 	Server struct {
 		Address  string `yaml:"address"`
-		Port     string `yaml:"port"`   //端口
-		Search   bool   `yaml:"search"` //允许搜索
+		Port     string `yaml:"port"`     //端口
+		Search   bool   `yaml:"search"`   //允许搜索
+		Download bool   `yaml:"download"` //允许下载
 		Static   string `yaml:"static"`
 		SiteUrl  string `yaml:"site_url"` //网站url
 		Password string `yaml:"password"`

--- a/server/router.go
+++ b/server/router.go
@@ -16,11 +16,11 @@ func InitRouter(engine *gin.Engine) {
 	engine.NoRoute(func(c *gin.Context) {
 		c.File(conf.Conf.Server.Static + "/index.html")
 	})
-	InitApiRouter(engine)
+	InitApiRouter(engine, conf.Conf.Server.Download)
 }
 
 // init api router
-func InitApiRouter(engine *gin.Engine) {
+func InitApiRouter(engine *gin.Engine, download bool) {
 	apiV2 := engine.Group("/api")
 	{
 		apiV2.GET("/info", controllers.Info)
@@ -32,5 +32,7 @@ func InitApiRouter(engine *gin.Engine) {
 		apiV2.POST("/global_search", controllers.GlobalSearch)
 		apiV2.POST("/rebuild", controllers.RebuildTree)
 	}
-	engine.GET("/d/*path", controllers.Down)
+	if download {
+		engine.GET("/d/*path", controllers.Down)
+	}
 }


### PR DESCRIPTION
#117 
添加了一个 `download` 配置项目，当设置为 `false` 时不允许用户获取直链。

当禁止获取直链时，预览等功能不可用，在前端页面也没必要显示复制直链/下载等按钮，可以使用临时修改版的 [sihuan/alist-web/transonly](https://github.com/sihuan/alist-web/tree/transonly)