### PR TITLE
feat: add aria2 support

### DIFF
--- a/bootstrap/setting.go
+++ b/bootstrap/setting.go
@@ -266,6 +266,22 @@ func InitSettings() {
 			Group:       model.BACK,
 			Description: "Experimental function, not recommended as it's still under development",
 		},
+		{
+			Key:         "Aria2 RPC url",
+			Value:       "",
+			Description: "Aria2 RPC url, e.g. 'http://aria2.example.com:6800/jsonrpc'",
+			Type:        "string",
+			Access:      model.PRIVATE,
+			Group:       model.BACK,
+		},
+		{
+			Key:         "Aria2 RPC secret",
+			Value:       "",
+			Description: "Aria2 RPC secret, e.g. '123456'",
+			Type:        "string",
+			Access:      model.PRIVATE,
+			Group:       model.BACK,
+		},
 	}
 	for i, _ := range settings {
 		v := settings[i]

--- a/bootstrap/setting.go
+++ b/bootstrap/setting.go
@@ -268,7 +268,7 @@ func InitSettings() {
 		},
 		{
 			Key:         "Aria2 RPC url",
-			Value:       "",
+			Value:       "http://localhost:6800/jsonrpc",
 			Description: "Aria2 RPC url, e.g. 'http://aria2.example.com:6800/jsonrpc'",
 			Type:        "string",
 			Access:      model.PRIVATE,


### PR DESCRIPTION
在右键菜单中增加了使用aria2下载的item，可以直接发送选中的文件链接到aria2，省略复制再粘贴到aria2的步骤