### PR TITLE
对123盘的部分api更新

### DIFF
--- a/drivers/123/123.go
+++ b/drivers/123/123.go
@@ -3,14 +3,15 @@ package _23
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
+	"strconv"
+
 	"github.com/Xhofe/alist/drivers/base"
 	"github.com/Xhofe/alist/model"
 	"github.com/Xhofe/alist/utils"
 	"github.com/go-resty/resty/v2"
 	jsoniter "github.com/json-iterator/go"
 	log "github.com/sirupsen/logrus"
-	"path/filepath"
-	"strconv"
 )
 
 func (driver Pan123) Login(account *model.Account) error {

--- a/drivers/123/123.go
+++ b/drivers/123/123.go
@@ -47,6 +47,7 @@ func (driver Pan123) FormatFile(file *File) *model.File {
 		Size:      file.Size,
 		Driver:    driver.Config().Name,
 		UpdatedAt: file.UpdateAt,
+		Thumbnail: file.DownloadUrl,
 	}
 	f.Type = file.GetType()
 	return f
@@ -66,7 +67,7 @@ func (driver Pan123) GetFiles(parentId string, account *model.Account) ([]File, 
 			"parentFileId":   parentId,
 			"trashed":        "false",
 		}
-		_, err := driver.Request("https://www.123pan.com/api/file/list",
+		_, err := driver.Request("https://www.123pan.com/api/file/list/new",
 			base.Get, nil, query, nil, &resp, false, account)
 		if err != nil {
 			return nil, err

--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -126,7 +126,7 @@ func (driver Pan123) Files(path string, account *model.Account) ([]model.File, e
 			_ = base.SetCache(path, rawFiles, account)
 		}
 	}
-	files := make([]model.File, 0)
+	files := make([]model.File, 0, len(rawFiles))
 	for _, file := range rawFiles {
 		files = append(files, *driver.FormatFile(&file))
 	}

--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -4,6 +4,13 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+
 	"github.com/Xhofe/alist/conf"
 	"github.com/Xhofe/alist/drivers/base"
 	"github.com/Xhofe/alist/model"
@@ -13,12 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	log "github.com/sirupsen/logrus"
-	"io"
-	"io/ioutil"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strconv"
 )
 
 type Pan123 struct{}
@@ -300,46 +301,36 @@ func (driver Pan123) Upload(file *model.FileStream, account *model.Account) erro
 	if !parentFile.IsDir() {
 		return base.ErrNotFolder
 	}
-	parentFileId, _ := strconv.Atoi(parentFile.Id)
+
 	tempFile, err := ioutil.TempFile(conf.Conf.TempDir, "file-*")
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = tempFile.Close()
-		_ = os.Remove(tempFile.Name())
-	}()
-	_, err = io.Copy(tempFile, file)
-	if err != nil {
-		return err
-	}
-	_, err = tempFile.Seek(0, io.SeekStart)
-	if err != nil {
-		return err
-	}
+	defer tempFile.Close()
+	defer os.Remove(tempFile.Name())
 	h := md5.New()
-	_, err = io.Copy(h, tempFile)
-	if err != nil {
+	if _, err = io.Copy(io.MultiWriter(tempFile, h), file); err != nil {
 		return err
 	}
 	etag := hex.EncodeToString(h.Sum(nil))
-	log.Debugln("md5:", etag)
+
 	_, err = tempFile.Seek(0, io.SeekStart)
 	if err != nil {
 		return err
 	}
+
 	data := base.Json{
 		"driveId":      0,
-		"duplicate":    true,
+		"duplicate":    2, // 2->覆盖 1->重命名 0->默认
 		"etag":         etag,
 		"fileName":     file.GetFileName(),
-		"parentFileId": parentFileId,
+		"parentFileId": parentFile.Id,
 		"size":         file.GetSize(),
 		"type":         0,
 	}
 	var resp UploadResp
 	_, err = driver.Request("https://www.123pan.com/api/file/upload_request",
-		base.Post, nil, nil, &data, &resp, false, account)
+		base.Post, map[string]string{"app-version": "1.1"}, nil, &data, &resp, false, account)
 	//res, err := driver.Post("https://www.123pan.com/api/file/upload_request", data, account)
 	if err != nil {
 		return err

--- a/drivers/123/types.go
+++ b/drivers/123/types.go
@@ -1,20 +1,22 @@
 package _23
 
 import (
-	"github.com/Xhofe/alist/conf"
-	"github.com/Xhofe/alist/utils"
 	"path"
 	"time"
+
+	"github.com/Xhofe/alist/conf"
+	"github.com/Xhofe/alist/utils"
 )
 
 type File struct {
-	FileName  string     `json:"FileName"`
-	Size      int64      `json:"Size"`
-	UpdateAt  *time.Time `json:"UpdateAt"`
-	FileId    int64      `json:"FileId"`
-	Type      int        `json:"Type"`
-	Etag      string     `json:"Etag"`
-	S3KeyFlag string     `json:"S3KeyFlag"`
+	FileName    string     `json:"FileName"`
+	Size        int64      `json:"Size"`
+	UpdateAt    *time.Time `json:"UpdateAt"`
+	FileId      int64      `json:"FileId"`
+	Type        int        `json:"Type"`
+	Etag        string     `json:"Etag"`
+	S3KeyFlag   string     `json:"S3KeyFlag"`
+	DownloadUrl string     `json:"DownloadUrl"`
 }
 
 func (f File) GetSize() uint64 {


### PR DESCRIPTION
尝试写死md5发现，但最终结果会使上传文件etag固定（貌似服务器端不会重新计算，就不怕秒传混乱吗），秒传的机制大概是etag+size，为避免污染秒传，所以无法实现流上传