### PR TITLE
fix: filename is urlencoded when using Safari

### DIFF
--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -26,7 +26,7 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *base.Link, file *model.
 			_ = link.Data.Close()
 		}()
 		w.Header().Set("Content-Type", "application/octet-stream")
-		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%s`, file.Name))
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, file.Name, url.QueryEscape(file.Name)))
 		w.Header().Set("Content-Length", strconv.FormatInt(file.Size, 10))
 		if link.Header != nil {
 			for h, val := range link.Header {
@@ -57,7 +57,7 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *base.Link, file *model.
 		if err != nil {
 			return err
 		}
-		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%s`, url.QueryEscape(file.Name)))
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, file.Name, url.QueryEscape(file.Name)))
 		http.ServeContent(w, r, file.Name, fileStat.ModTime(), f)
 		return nil
 	} else {


### PR DESCRIPTION
修复在Safari浏览器中下载文件时，文件名会被url编码的问题